### PR TITLE
combined lane-jumping and street-generation

### DIFF
--- a/Assets/LaneJumping/PlayerJumpPreset.asset
+++ b/Assets/LaneJumping/PlayerJumpPreset.asset
@@ -12,37 +12,37 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 33d89e0d1ee67ae4c9ba880920b5e23c, type: 3}
   m_Name: PlayerJumpPreset
   m_EditorClassIdentifier: 
-  jumpDuration: 0.2
+  jumpDuration: 0.3
   verticalMovement:
     serializedVersion: 2
     m_Curve:
     - serializedVersion: 3
       time: 0
       value: 0
-      inSlope: 4.3063684
-      outSlope: 4.3063684
+      inSlope: 6.385708
+      outSlope: 6.385708
       tangentMode: 0
-      weightedMode: 0
+      weightedMode: 2
       inWeight: 0
-      outWeight: 0.333111
+      outWeight: 0.2328145
     - serializedVersion: 3
-      time: 0.23100257
-      value: 2.0293903
-      inSlope: 0.24543978
-      outSlope: 0.05009036
-      tangentMode: 1
+      time: 0.5266789
+      value: 1.7561821
+      inSlope: 0.08484792
+      outSlope: 0.08484792
+      tangentMode: 0
       weightedMode: 3
-      inWeight: 0.46695477
-      outWeight: 0.47708267
+      inWeight: 0.4712948
+      outWeight: 0.33086514
     - serializedVersion: 3
       time: 1
       value: 0
-      inSlope: -1.9571949
-      outSlope: -1.9571949
+      inSlope: -10.379455
+      outSlope: -10.379455
       tangentMode: 0
-      weightedMode: 1
-      inWeight: 0.771479
-      outWeight: 0
+      weightedMode: 0
+      inWeight: 0.09421917
+      outWeight: 0.33333334
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
@@ -52,22 +52,22 @@ MonoBehaviour:
     - serializedVersion: 3
       time: 0
       value: 0
-      inSlope: 1.9039401
-      outSlope: 1.9039401
-      tangentMode: 0
+      inSlope: 1
+      outSlope: 1
+      tangentMode: 34
       weightedMode: 0
       inWeight: 0
-      outWeight: 0.04237288
+      outWeight: 0
     - serializedVersion: 3
       time: 1
       value: 1
-      inSlope: 0.1443836
-      outSlope: 0.1443836
-      tangentMode: 0
+      inSlope: 1
+      outSlope: 1
+      tangentMode: 34
       weightedMode: 0
-      inWeight: 0.1949153
+      inWeight: 0
       outWeight: 0
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
-  offsetOffLane: {x: 0, y: 1.46, z: 0}
+  offsetOffLane: {x: 0, y: 0.6, z: 0}

--- a/Assets/Prefabs/CompleteStreet.prefab
+++ b/Assets/Prefabs/CompleteStreet.prefab
@@ -1,0 +1,774 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1474036372749117041
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4305459818890262206}
+  m_Layer: 0
+  m_Name: CompleteStreet
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4305459818890262206
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1474036372749117041}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -1.7038733, y: -4.832025, z: 9.253582}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7400547151307757803}
+  - {fileID: 7400547151825327825}
+  - {fileID: 7400547151325299402}
+  - {fileID: 7400547152186154840}
+  - {fileID: 7400547150957684146}
+  - {fileID: 7400547151403130096}
+  - {fileID: 7400547151958667217}
+  - {fileID: 6135133885522760798}
+  - {fileID: 2732862835164756220}
+  - {fileID: 6004326964778860349}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &6135133885522760792
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6135133885522760798}
+  - component: {fileID: 6135133885522760799}
+  m_Layer: 0
+  m_Name: StreetGenerator
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6135133885522760798
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6135133885522760792}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.068, z: 56.5}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4305459818890262206}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &6135133885522760799
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6135133885522760792}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1b842b68dc280314e9b88eba09b726e3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  StreetLenght: 8
+  StreetWidth: 5
+  ActiveStreetTiles: 10
+  ScrollSpeed: 10
+  DecorationSpawnRate: 0.851
+  DecorationSpawnAreaWidth: 40
+  StreetPrefab: {fileID: 3228188957336666035, guid: 11921375eec9a034089e74408a2ee739,
+    type: 3}
+  ObstaclePrefab: {fileID: 6290650405965434039, guid: 4ce72af9a6f7e8346b7a8c1fcd3d5e2c,
+    type: 3}
+  DecorationPrefab: {fileID: 8647712531606356591, guid: 597a1a8ae490c4e4793bfa3cf06ce5bc,
+    type: 3}
+--- !u!1001 &3924601568956778331
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 4305459818890262206}
+    m_Modifications:
+    - target: {fileID: 1412978070226255782, guid: 06cb4109dbee0224bbeab4ce4b8e2ded,
+        type: 3}
+      propertyPath: m_Name
+      value: JumpableLane
+      objectReference: {fileID: 0}
+    - target: {fileID: 1412978070226255783, guid: 06cb4109dbee0224bbeab4ce4b8e2ded,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 1412978070226255783, guid: 06cb4109dbee0224bbeab4ce4b8e2ded,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.914
+      objectReference: {fileID: 0}
+    - target: {fileID: 1412978070226255783, guid: 06cb4109dbee0224bbeab4ce4b8e2ded,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.045
+      objectReference: {fileID: 0}
+    - target: {fileID: 1412978070226255783, guid: 06cb4109dbee0224bbeab4ce4b8e2ded,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 56.671
+      objectReference: {fileID: 0}
+    - target: {fileID: 1412978070226255783, guid: 06cb4109dbee0224bbeab4ce4b8e2ded,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1412978070226255783, guid: 06cb4109dbee0224bbeab4ce4b8e2ded,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1412978070226255783, guid: 06cb4109dbee0224bbeab4ce4b8e2ded,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1412978070226255783, guid: 06cb4109dbee0224bbeab4ce4b8e2ded,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1412978070226255783, guid: 06cb4109dbee0224bbeab4ce4b8e2ded,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1412978070226255783, guid: 06cb4109dbee0224bbeab4ce4b8e2ded,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1412978070226255783, guid: 06cb4109dbee0224bbeab4ce4b8e2ded,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 06cb4109dbee0224bbeab4ce4b8e2ded, type: 3}
+--- !u!4 &2732862835164756220 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1412978070226255783, guid: 06cb4109dbee0224bbeab4ce4b8e2ded,
+    type: 3}
+  m_PrefabInstance: {fileID: 3924601568956778331}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &4668068555499094170
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 4305459818890262206}
+    m_Modifications:
+    - target: {fileID: 1412978070226255782, guid: 06cb4109dbee0224bbeab4ce4b8e2ded,
+        type: 3}
+      propertyPath: m_Name
+      value: JumpableLane (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 1412978070226255783, guid: 06cb4109dbee0224bbeab4ce4b8e2ded,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 1412978070226255783, guid: 06cb4109dbee0224bbeab4ce4b8e2ded,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.938
+      objectReference: {fileID: 0}
+    - target: {fileID: 1412978070226255783, guid: 06cb4109dbee0224bbeab4ce4b8e2ded,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.045
+      objectReference: {fileID: 0}
+    - target: {fileID: 1412978070226255783, guid: 06cb4109dbee0224bbeab4ce4b8e2ded,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 56.671
+      objectReference: {fileID: 0}
+    - target: {fileID: 1412978070226255783, guid: 06cb4109dbee0224bbeab4ce4b8e2ded,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1412978070226255783, guid: 06cb4109dbee0224bbeab4ce4b8e2ded,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1412978070226255783, guid: 06cb4109dbee0224bbeab4ce4b8e2ded,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1412978070226255783, guid: 06cb4109dbee0224bbeab4ce4b8e2ded,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1412978070226255783, guid: 06cb4109dbee0224bbeab4ce4b8e2ded,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1412978070226255783, guid: 06cb4109dbee0224bbeab4ce4b8e2ded,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1412978070226255783, guid: 06cb4109dbee0224bbeab4ce4b8e2ded,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 06cb4109dbee0224bbeab4ce4b8e2ded, type: 3}
+--- !u!4 &6004326964778860349 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1412978070226255783, guid: 06cb4109dbee0224bbeab4ce4b8e2ded,
+    type: 3}
+  m_PrefabInstance: {fileID: 4668068555499094170}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &6135133883563785656
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 4305459818890262206}
+    m_Modifications:
+    - target: {fileID: 3228188957336666035, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_Name
+      value: Street (4)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 100.17642
+      objectReference: {fileID: 0}
+    - target: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 11921375eec9a034089e74408a2ee739, type: 3}
+--- !u!4 &7400547150957684146 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+    type: 3}
+  m_PrefabInstance: {fileID: 6135133883563785656}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &6135133884213167354
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 4305459818890262206}
+    m_Modifications:
+    - target: {fileID: 3228188957336666035, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_Name
+      value: Street (5)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 108.17642
+      objectReference: {fileID: 0}
+    - target: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 11921375eec9a034089e74408a2ee739, type: 3}
+--- !u!4 &7400547151403130096 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+    type: 3}
+  m_PrefabInstance: {fileID: 6135133884213167354}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &6135133884269107904
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 4305459818890262206}
+    m_Modifications:
+    - target: {fileID: 3228188957336666035, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_Name
+      value: Street (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 84.17642
+      objectReference: {fileID: 0}
+    - target: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 11921375eec9a034089e74408a2ee739, type: 3}
+--- !u!4 &7400547151325299402 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+    type: 3}
+  m_PrefabInstance: {fileID: 6135133884269107904}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &6135133884283535585
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 4305459818890262206}
+    m_Modifications:
+    - target: {fileID: 3228188957336666035, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_Name
+      value: Street
+      objectReference: {fileID: 0}
+    - target: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 68.17642
+      objectReference: {fileID: 0}
+    - target: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 11921375eec9a034089e74408a2ee739, type: 3}
+--- !u!4 &7400547151307757803 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+    type: 3}
+  m_PrefabInstance: {fileID: 6135133884283535585}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &6135133884701145051
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 4305459818890262206}
+    m_Modifications:
+    - target: {fileID: 3228188957336666035, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_Name
+      value: Street (6)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 60.17642
+      objectReference: {fileID: 0}
+    - target: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 11921375eec9a034089e74408a2ee739, type: 3}
+--- !u!4 &7400547151958667217 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+    type: 3}
+  m_PrefabInstance: {fileID: 6135133884701145051}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &6135133884834598619
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 4305459818890262206}
+    m_Modifications:
+    - target: {fileID: 3228188957336666035, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_Name
+      value: Street (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 76.17642
+      objectReference: {fileID: 0}
+    - target: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 11921375eec9a034089e74408a2ee739, type: 3}
+--- !u!4 &7400547151825327825 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+    type: 3}
+  m_PrefabInstance: {fileID: 6135133884834598619}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &6135133885027125074
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 4305459818890262206}
+    m_Modifications:
+    - target: {fileID: 3228188957336666035, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_Name
+      value: Street (3)
+      objectReference: {fileID: 0}
+    - target: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 92.17642
+      objectReference: {fileID: 0}
+    - target: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 11921375eec9a034089e74408a2ee739, type: 3}
+--- !u!4 &7400547152186154840 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3715568303135299594, guid: 11921375eec9a034089e74408a2ee739,
+    type: 3}
+  m_PrefabInstance: {fileID: 6135133885027125074}
+  m_PrefabAsset: {fileID: 0}

--- a/Assets/Prefabs/CompleteStreet.prefab
+++ b/Assets/Prefabs/CompleteStreet.prefab
@@ -85,6 +85,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1b842b68dc280314e9b88eba09b726e3, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  gameState: {fileID: 11400000, guid: 4ff2533ef39672f4d938a8563cb2dce3, type: 2}
   StreetLenght: 8
   StreetWidth: 5
   ActiveStreetTiles: 10

--- a/Assets/Prefabs/CompleteStreet.prefab.meta
+++ b/Assets/Prefabs/CompleteStreet.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 1bcf13fc7bdfc394890a98bfe12c98cc
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/JumpableLane.prefab
+++ b/Assets/Prefabs/JumpableLane.prefab
@@ -1,0 +1,33 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1412978070226255782
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1412978070226255783}
+  m_Layer: 0
+  m_Name: JumpableLane
+  m_TagString: lane
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1412978070226255783
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1412978070226255782}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -12.23, y: 0.35, z: 67.60947}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Prefabs/JumpableLane.prefab.meta
+++ b/Assets/Prefabs/JumpableLane.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 06cb4109dbee0224bbeab4ce4b8e2ded
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/CombinationTest.unity
+++ b/Assets/Scenes/CombinationTest.unity
@@ -1,0 +1,819 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 705507994}
+  m_IndirectSpecularColor: {r: 0.44657898, g: 0.4964133, b: 0.5748178, a: 1}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 12
+  m_GIWorkflowMode: 1
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 500
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 500
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 2
+    m_PVRDenoiserTypeDirect: 0
+    m_PVRDenoiserTypeIndirect: 0
+    m_PVRDenoiserTypeAO: 0
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 0
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 0}
+  m_LightingSettings: {fileID: 0}
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 2
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    accuratePlacement: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1001 &153587212
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 2064056540}
+    m_Modifications:
+    - target: {fileID: 6290650405965434039, guid: 4ce72af9a6f7e8346b7a8c1fcd3d5e2c,
+        type: 3}
+      propertyPath: m_Name
+      value: Car
+      objectReference: {fileID: 0}
+    - target: {fileID: 8431656997936273403, guid: 4ce72af9a6f7e8346b7a8c1fcd3d5e2c,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8431656997936273403, guid: 4ce72af9a6f7e8346b7a8c1fcd3d5e2c,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8431656997936273403, guid: 4ce72af9a6f7e8346b7a8c1fcd3d5e2c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8431656997936273403, guid: 4ce72af9a6f7e8346b7a8c1fcd3d5e2c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8431656997936273403, guid: 4ce72af9a6f7e8346b7a8c1fcd3d5e2c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8431656997936273403, guid: 4ce72af9a6f7e8346b7a8c1fcd3d5e2c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8431656997936273403, guid: 4ce72af9a6f7e8346b7a8c1fcd3d5e2c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8431656997936273403, guid: 4ce72af9a6f7e8346b7a8c1fcd3d5e2c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8431656997936273403, guid: 4ce72af9a6f7e8346b7a8c1fcd3d5e2c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8431656997936273403, guid: 4ce72af9a6f7e8346b7a8c1fcd3d5e2c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8431656997936273403, guid: 4ce72af9a6f7e8346b7a8c1fcd3d5e2c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8431656997936273403, guid: 4ce72af9a6f7e8346b7a8c1fcd3d5e2c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 4ce72af9a6f7e8346b7a8c1fcd3d5e2c, type: 3}
+--- !u!1001 &293846355
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1378103656}
+    m_Modifications:
+    - target: {fileID: 1474036372749117041, guid: 1bcf13fc7bdfc394890a98bfe12c98cc,
+        type: 3}
+      propertyPath: m_Name
+      value: CompleteStreet (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4305459818890262206, guid: 1bcf13fc7bdfc394890a98bfe12c98cc,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4305459818890262206, guid: 1bcf13fc7bdfc394890a98bfe12c98cc,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 9.8
+      objectReference: {fileID: 0}
+    - target: {fileID: 4305459818890262206, guid: 1bcf13fc7bdfc394890a98bfe12c98cc,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 2.7
+      objectReference: {fileID: 0}
+    - target: {fileID: 4305459818890262206, guid: 1bcf13fc7bdfc394890a98bfe12c98cc,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 9.253582
+      objectReference: {fileID: 0}
+    - target: {fileID: 4305459818890262206, guid: 1bcf13fc7bdfc394890a98bfe12c98cc,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4305459818890262206, guid: 1bcf13fc7bdfc394890a98bfe12c98cc,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4305459818890262206, guid: 1bcf13fc7bdfc394890a98bfe12c98cc,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4305459818890262206, guid: 1bcf13fc7bdfc394890a98bfe12c98cc,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4305459818890262206, guid: 1bcf13fc7bdfc394890a98bfe12c98cc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4305459818890262206, guid: 1bcf13fc7bdfc394890a98bfe12c98cc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4305459818890262206, guid: 1bcf13fc7bdfc394890a98bfe12c98cc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1bcf13fc7bdfc394890a98bfe12c98cc, type: 3}
+--- !u!4 &293846356 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4305459818890262206, guid: 1bcf13fc7bdfc394890a98bfe12c98cc,
+    type: 3}
+  m_PrefabInstance: {fileID: 293846355}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &538812110 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8431656997936273403, guid: 4ce72af9a6f7e8346b7a8c1fcd3d5e2c,
+    type: 3}
+  m_PrefabInstance: {fileID: 153587212}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &705507993
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 705507995}
+  - component: {fileID: 705507994}
+  m_Layer: 0
+  m_Name: Directional Light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!108 &705507994
+Light:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 705507993}
+  m_Enabled: 1
+  serializedVersion: 10
+  m_Type: 1
+  m_Shape: 0
+  m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
+  m_Intensity: 1
+  m_Range: 10
+  m_SpotAngle: 30
+  m_InnerSpotAngle: 21.80208
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 2
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingLayerMask: 1
+  m_Lightmapping: 1
+  m_LightShadowCasterMode: 0
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
+  m_UseViewFrustumForShadowCasterCull: 1
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+--- !u!4 &705507995
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 705507993}
+  m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
+  m_LocalPosition: {x: 0, y: 3, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!1 &773505121
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 773505125}
+  - component: {fileID: 773505124}
+  - component: {fileID: 773505123}
+  - component: {fileID: 773505122}
+  m_Layer: 0
+  m_Name: Plane
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!64 &773505122
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 773505121}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 4
+  m_Convex: 0
+  m_CookingOptions: 30
+  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &773505123
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 773505121}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: e67a7c6e75de58c45bf7df7d13da8508, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &773505124
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 773505121}
+  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &773505125
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 773505121}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -89.6}
+  m_LocalScale: {x: 15.858, y: 1, z: 27.405302}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1190486515}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &963194225
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 963194228}
+  - component: {fileID: 963194227}
+  - component: {fileID: 963194226}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!81 &963194226
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 963194225}
+  m_Enabled: 1
+--- !u!20 &963194227
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 963194225}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_FocalLength: 50
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &963194228
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 963194225}
+  m_LocalRotation: {x: 0.08499394, y: -0, z: -0, w: 0.99638146}
+  m_LocalPosition: {x: 0, y: 1.294, z: -3.22}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2064056540}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 9.751, y: 0, z: 0}
+--- !u!1 &1190486514
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1190486515}
+  m_Layer: 0
+  m_Name: env
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1190486515
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1190486514}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 64}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 773505125}
+  m_Father: {fileID: 0}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1378103655
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1378103656}
+  m_Layer: 0
+  m_Name: StreetLanes
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1378103656
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1378103655}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1891200670}
+  - {fileID: 2136209776}
+  - {fileID: 293846356}
+  m_Father: {fileID: 0}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1891200669
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1378103656}
+    m_Modifications:
+    - target: {fileID: 1474036372749117041, guid: 1bcf13fc7bdfc394890a98bfe12c98cc,
+        type: 3}
+      propertyPath: m_Name
+      value: CompleteStreet
+      objectReference: {fileID: 0}
+    - target: {fileID: 4305459818890262206, guid: 1bcf13fc7bdfc394890a98bfe12c98cc,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4305459818890262206, guid: 1bcf13fc7bdfc394890a98bfe12c98cc,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -11.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4305459818890262206, guid: 1bcf13fc7bdfc394890a98bfe12c98cc,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4305459818890262206, guid: 1bcf13fc7bdfc394890a98bfe12c98cc,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 9.253582
+      objectReference: {fileID: 0}
+    - target: {fileID: 4305459818890262206, guid: 1bcf13fc7bdfc394890a98bfe12c98cc,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4305459818890262206, guid: 1bcf13fc7bdfc394890a98bfe12c98cc,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4305459818890262206, guid: 1bcf13fc7bdfc394890a98bfe12c98cc,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4305459818890262206, guid: 1bcf13fc7bdfc394890a98bfe12c98cc,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4305459818890262206, guid: 1bcf13fc7bdfc394890a98bfe12c98cc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4305459818890262206, guid: 1bcf13fc7bdfc394890a98bfe12c98cc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4305459818890262206, guid: 1bcf13fc7bdfc394890a98bfe12c98cc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1bcf13fc7bdfc394890a98bfe12c98cc, type: 3}
+--- !u!4 &1891200670 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4305459818890262206, guid: 1bcf13fc7bdfc394890a98bfe12c98cc,
+    type: 3}
+  m_PrefabInstance: {fileID: 1891200669}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &2064056539
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2064056540}
+  - component: {fileID: 2064056541}
+  m_Layer: 0
+  m_Name: Player
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2064056540
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2064056539}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1.11, z: -2.53}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 963194228}
+  - {fileID: 538812110}
+  m_Father: {fileID: 0}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2064056541
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2064056539}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d9a91b683739fa445b47c747d41a6acf, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  jumpPreset: {fileID: 11400000, guid: edc2895a2f4ae6040987660e742ac822, type: 2}
+--- !u!1001 &2136209775
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1378103656}
+    m_Modifications:
+    - target: {fileID: 1474036372749117041, guid: 1bcf13fc7bdfc394890a98bfe12c98cc,
+        type: 3}
+      propertyPath: m_Name
+      value: CompleteStreet (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 4305459818890262206, guid: 1bcf13fc7bdfc394890a98bfe12c98cc,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4305459818890262206, guid: 1bcf13fc7bdfc394890a98bfe12c98cc,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1.7038733
+      objectReference: {fileID: 0}
+    - target: {fileID: 4305459818890262206, guid: 1bcf13fc7bdfc394890a98bfe12c98cc,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4305459818890262206, guid: 1bcf13fc7bdfc394890a98bfe12c98cc,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 9.253582
+      objectReference: {fileID: 0}
+    - target: {fileID: 4305459818890262206, guid: 1bcf13fc7bdfc394890a98bfe12c98cc,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4305459818890262206, guid: 1bcf13fc7bdfc394890a98bfe12c98cc,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4305459818890262206, guid: 1bcf13fc7bdfc394890a98bfe12c98cc,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4305459818890262206, guid: 1bcf13fc7bdfc394890a98bfe12c98cc,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4305459818890262206, guid: 1bcf13fc7bdfc394890a98bfe12c98cc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4305459818890262206, guid: 1bcf13fc7bdfc394890a98bfe12c98cc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4305459818890262206, guid: 1bcf13fc7bdfc394890a98bfe12c98cc,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1bcf13fc7bdfc394890a98bfe12c98cc, type: 3}
+--- !u!4 &2136209776 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4305459818890262206, guid: 1bcf13fc7bdfc394890a98bfe12c98cc,
+    type: 3}
+  m_PrefabInstance: {fileID: 2136209775}
+  m_PrefabAsset: {fileID: 0}

--- a/Assets/Scenes/CombinationTest.unity.meta
+++ b/Assets/Scenes/CombinationTest.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: eb7065e00a0729d4e9558240dce25a91
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/StreetGenerator.cs
+++ b/Assets/Scripts/StreetGenerator.cs
@@ -5,10 +5,13 @@ using UnityEngine;
 
 public class StreetGenerator : MonoBehaviour
 {
+    [SerializeField] GameState gameState;
+
     public float StreetLenght = 10;
     public float StreetWidth = 5; 
     public float ActiveStreetTiles = 5;
-    public float ScrollSpeed = 1f;
+    private float ScrollSpeed;
+    private float ScrollSpeedFactor = 7f; // If gameState.speed should be taken directly as ScrollSpeed, set to 0
     [Range (0f, 1f)]
     public float DecorationSpawnRate = 0.5f;
     public float DecorationSpawnAreaWidth = 20f;
@@ -48,6 +51,8 @@ public class StreetGenerator : MonoBehaviour
 
     void Update()
     {
+        ScrollSpeed = gameState.speed * ScrollSpeedFactor;
+
         //Street loop
         foreach (var item in _streetQueue)
         {

--- a/Assets/Scripts/StreetGenerator.cs
+++ b/Assets/Scripts/StreetGenerator.cs
@@ -26,7 +26,7 @@ public class StreetGenerator : MonoBehaviour
     {
         for (int i = 0; i < ActiveStreetTiles; i++)
         {
-            var s = Instantiate(StreetPrefab, new Vector3(0, 0, (i) * StreetLenght), Quaternion.identity,transform);
+            var s = Instantiate(StreetPrefab, new Vector3(transform.position.x, transform.position.y, (i) * StreetLenght), Quaternion.identity,transform);
             _streetQueue.Enqueue(s);
             _lastAdded = s;
 


### PR DESCRIPTION
PlayerJump-preset wurde auf das neue Layout angepasst und in StreetGenerator.cs mussste eine Zeile zu relativen Koordinaten geändert werden, damit mehere Straßen neben einander generier werden können.
Der Rest ist alleinstehend